### PR TITLE
都道府県と人口データのAPI取得を実装

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,3 @@
+export default function Loading() {
+  return <p>⏳レスポンス待ち。。。</p>;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,8 @@
+import { getPrefectures } from '@/services/api';
 import PrefectureSelector from '@/components/PrefectureSelector';
 
-export default function Home() {
+export default async function Home() {
+  const prefectures = await getPrefectures();
   return (
     <div className="flex flex-col min-h-screen">
       <header className="p-5 text-center text-xl font-semibold">
@@ -10,7 +12,7 @@ export default function Home() {
         <p className="text-gray-700 dark:text-gray-300">
           This is a minimal Next.js setup.
         </p>
-        <PrefectureSelector />
+        <PrefectureSelector prefectures={prefectures} />
       </main>
       <footer className="p-5 text-center text-sm text-gray-500">
         © {new Date().getFullYear()} Firas. All rights reserved.

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,3 +1,5 @@
+import PrefectureSelector from '@/components/PrefectureSelector';
+
 export default function Home() {
   return (
     <div className="flex flex-col min-h-screen">
@@ -8,6 +10,7 @@ export default function Home() {
         <p className="text-gray-700 dark:text-gray-300">
           This is a minimal Next.js setup.
         </p>
+        <PrefectureSelector />
       </main>
       <footer className="p-5 text-center text-sm text-gray-500">
         © {new Date().getFullYear()} Firas. All rights reserved.

--- a/src/components/PrefectureSelector.tsx
+++ b/src/components/PrefectureSelector.tsx
@@ -1,4 +1,4 @@
-import getPrefectures from '@/services/api';
+import { getPrefectures } from '@/services/api';
 import { Key } from 'react';
 
 export default async function PrefectureSelector() {

--- a/src/components/PrefectureSelector.tsx
+++ b/src/components/PrefectureSelector.tsx
@@ -1,8 +1,12 @@
-import { getPrefectures } from '@/services/api';
+'use client';
+
 import { Key } from 'react';
 
-export default async function PrefectureSelector() {
-  const prefectures = await getPrefectures();
+export default function PrefectureSelector({
+  prefectures,
+}: {
+  prefectures: { prefCode: number; prefName: string }[];
+}) {
   return (
     <>
       <div className="flex flex-wrap w-108 space-x-2">

--- a/src/components/PrefectureSelector.tsx
+++ b/src/components/PrefectureSelector.tsx
@@ -1,0 +1,22 @@
+import getPrefectures from '@/services/api';
+import { Key } from 'react';
+
+export default async function PrefectureSelector() {
+  const prefectures = await getPrefectures();
+  return (
+    <>
+      <div className="flex flex-wrap w-108 space-x-2">
+        {prefectures.map((prefecture: { prefCode: Key; prefName: string }) => {
+          return (
+            <div key={prefecture.prefCode} className="flex space-x-2 w-25">
+              <input type="checkbox" id={`pref-${prefecture.prefCode}`}></input>
+              <label htmlFor={`pref-${prefecture.prefCode}`}>
+                {prefecture.prefName}
+              </label>
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}

--- a/src/components/PrefectureSelector.tsx
+++ b/src/components/PrefectureSelector.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { Key } from 'react';
-
 export default function PrefectureSelector({
   prefectures,
 }: {
@@ -10,7 +8,7 @@ export default function PrefectureSelector({
   return (
     <>
       <div className="flex flex-wrap w-108 space-x-2">
-        {prefectures.map((prefecture: { prefCode: Key; prefName: string }) => {
+        {prefectures.map((prefecture: { prefCode: number; prefName: string }) => {
           return (
             <div key={prefecture.prefCode} className="flex space-x-2 w-25">
               <input type="checkbox" id={`pref-${prefecture.prefCode}`}></input>

--- a/src/components/PrefectureSelector.tsx
+++ b/src/components/PrefectureSelector.tsx
@@ -8,16 +8,21 @@ export default function PrefectureSelector({
   return (
     <>
       <div className="flex flex-wrap w-108 space-x-2">
-        {prefectures.map((prefecture: { prefCode: number; prefName: string }) => {
-          return (
-            <div key={prefecture.prefCode} className="flex space-x-2 w-25">
-              <input type="checkbox" id={`pref-${prefecture.prefCode}`}></input>
-              <label htmlFor={`pref-${prefecture.prefCode}`}>
-                {prefecture.prefName}
-              </label>
-            </div>
-          );
-        })}
+        {prefectures.map(
+          (prefecture: { prefCode: number; prefName: string }) => {
+            return (
+              <div key={prefecture.prefCode} className="flex space-x-2 w-25">
+                <input
+                  type="checkbox"
+                  id={`pref-${prefecture.prefCode}`}
+                ></input>
+                <label htmlFor={`pref-${prefecture.prefCode}`}>
+                  {prefecture.prefName}
+                </label>
+              </div>
+            );
+          }
+        )}
       </div>
     </>
   );

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,8 @@
 'use server';
 
 export default async function getPrefectures() {
+  // Commented out API fetch for local testing to avoid unnecessary API calls
+  /*
   const res = await fetch(
     `https://yumemi-frontend-engineer-codecheck-api.vercel.app/api/v1/prefectures`,
     {
@@ -16,6 +18,61 @@ export default async function getPrefectures() {
   }
 
   const json = await res.json();
+  */
+
+  // Using local mock data for development
+  const json = {
+    message: null,
+    result: [
+      { prefCode: 1, prefName: '北海道' },
+      { prefCode: 2, prefName: '青森県' },
+      { prefCode: 3, prefName: '岩手県' },
+      { prefCode: 4, prefName: '宮城県' },
+      { prefCode: 5, prefName: '秋田県' },
+      { prefCode: 6, prefName: '山形県' },
+      { prefCode: 7, prefName: '福島県' },
+      { prefCode: 8, prefName: '茨城県' },
+      { prefCode: 9, prefName: '栃木県' },
+      { prefCode: 10, prefName: '群馬県' },
+      { prefCode: 11, prefName: '埼玉県' },
+      { prefCode: 12, prefName: '千葉県' },
+      { prefCode: 13, prefName: '東京都' },
+      { prefCode: 14, prefName: '神奈川県' },
+      { prefCode: 15, prefName: '新潟県' },
+      { prefCode: 16, prefName: '富山県' },
+      { prefCode: 17, prefName: '石川県' },
+      { prefCode: 18, prefName: '福井県' },
+      { prefCode: 19, prefName: '山梨県' },
+      { prefCode: 20, prefName: '長野県' },
+      { prefCode: 21, prefName: '岐阜県' },
+      { prefCode: 22, prefName: '静岡県' },
+      { prefCode: 23, prefName: '愛知県' },
+      { prefCode: 24, prefName: '三重県' },
+      { prefCode: 25, prefName: '滋賀県' },
+      { prefCode: 26, prefName: '京都府' },
+      { prefCode: 27, prefName: '大阪府' },
+      { prefCode: 28, prefName: '兵庫県' },
+      { prefCode: 29, prefName: '奈良県' },
+      { prefCode: 30, prefName: '和歌山県' },
+      { prefCode: 31, prefName: '鳥取県' },
+      { prefCode: 32, prefName: '島根県' },
+      { prefCode: 33, prefName: '岡山県' },
+      { prefCode: 34, prefName: '広島県' },
+      { prefCode: 35, prefName: '山口県' },
+      { prefCode: 36, prefName: '徳島県' },
+      { prefCode: 37, prefName: '香川県' },
+      { prefCode: 38, prefName: '愛媛県' },
+      { prefCode: 39, prefName: '高知県' },
+      { prefCode: 40, prefName: '福岡県' },
+      { prefCode: 41, prefName: '佐賀県' },
+      { prefCode: 42, prefName: '長崎県' },
+      { prefCode: 43, prefName: '熊本県' },
+      { prefCode: 44, prefName: '大分県' },
+      { prefCode: 45, prefName: '宮崎県' },
+      { prefCode: 46, prefName: '鹿児島県' },
+      { prefCode: 47, prefName: '沖縄県' },
+    ],
+  };
 
   return json.result;
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,6 +1,6 @@
 'use server';
 
-export default async function getPrefectures() {
+export async function getPrefectures() {
   // Commented out API fetch for local testing to avoid unnecessary API calls
   /*
   const res = await fetch(

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -82,6 +82,8 @@ export async function getPopulation(prefCode: number) {
     throw new Error(`There is no prefecture with the code ${prefCode}`);
   }
 
+  // Commented out API fetch for local testing to avoid unnecessary API calls
+  /*
   const res = await fetch(
     `https://yumemi-frontend-engineer-codecheck-api.vercel.app/api/v1/population/composition/perYear?prefCode=${prefCode}`,
     {
@@ -97,6 +99,381 @@ export async function getPopulation(prefCode: number) {
   }
 
   const json = await res.json();
+  */
+
+  // Using local mock data (case prefCode=1) for development
+  const json = {
+    message: null,
+    result: [
+      {
+        boundaryYear: 2020,
+        data: [
+          {
+            label: '総人口',
+            data: [
+              {
+                year: 1960,
+                value: 5039206,
+              },
+              {
+                year: 1965,
+                value: 5171800,
+              },
+              {
+                year: 1970,
+                value: 5184287,
+              },
+              {
+                year: 1975,
+                value: 5338206,
+              },
+              {
+                year: 1980,
+                value: 5575989,
+              },
+              {
+                year: 1985,
+                value: 5679439,
+              },
+              {
+                year: 1990,
+                value: 5643647,
+              },
+              {
+                year: 1995,
+                value: 5692321,
+              },
+              {
+                year: 2000,
+                value: 5683062,
+              },
+              {
+                year: 2005,
+                value: 5627737,
+              },
+              {
+                year: 2010,
+                value: 5506419,
+              },
+              {
+                year: 2015,
+                value: 5381733,
+              },
+              {
+                year: 2020,
+                value: 5224614,
+              },
+              {
+                year: 2025,
+                value: 5016554,
+              },
+              {
+                year: 2030,
+                value: 4791592,
+              },
+              {
+                year: 2035,
+                value: 4546357,
+              },
+              {
+                year: 2040,
+                value: 4280427,
+              },
+              {
+                year: 2045,
+                value: 4004973,
+              },
+            ],
+          },
+          {
+            label: '年少人口',
+            data: [
+              {
+                year: 1960,
+                value: 1681479,
+                rate: 33.37,
+              },
+              {
+                year: 1965,
+                value: 1462123,
+                rate: 28.27,
+              },
+              {
+                year: 1970,
+                value: 1309487,
+                rate: 25.26,
+              },
+              {
+                year: 1975,
+                value: 1312611,
+                rate: 24.59,
+              },
+              {
+                year: 1980,
+                value: 1298324,
+                rate: 23.28,
+              },
+              {
+                year: 1985,
+                value: 1217959,
+                rate: 21.45,
+              },
+              {
+                year: 1990,
+                value: 1034251,
+                rate: 18.33,
+              },
+              {
+                year: 1995,
+                value: 898673,
+                rate: 15.79,
+              },
+              {
+                year: 2000,
+                value: 792352,
+                rate: 13.94,
+              },
+              {
+                year: 2005,
+                value: 719057,
+                rate: 12.78,
+              },
+              {
+                year: 2010,
+                value: 657312,
+                rate: 11.94,
+              },
+              {
+                year: 2015,
+                value: 608296,
+                rate: 11.3,
+              },
+              {
+                year: 2020,
+                value: 555804,
+                rate: 10.64,
+              },
+              {
+                year: 2025,
+                value: 511677,
+                rate: 10.2,
+              },
+              {
+                year: 2030,
+                value: 465307,
+                rate: 9.71,
+              },
+              {
+                year: 2035,
+                value: 423382,
+                rate: 9.31,
+              },
+              {
+                year: 2040,
+                value: 391086,
+                rate: 9.14,
+              },
+              {
+                year: 2045,
+                value: 360177,
+                rate: 8.99,
+              },
+            ],
+          },
+          {
+            label: '生産年齢人口',
+            data: [
+              {
+                year: 1960,
+                value: 3145664,
+                rate: 62.42,
+              },
+              {
+                year: 1965,
+                value: 3460359,
+                rate: 66.91,
+              },
+              {
+                year: 1970,
+                value: 3575731,
+                rate: 68.97,
+              },
+              {
+                year: 1975,
+                value: 3657884,
+                rate: 68.52,
+              },
+              {
+                year: 1980,
+                value: 3823808,
+                rate: 68.58,
+              },
+              {
+                year: 1985,
+                value: 3910729,
+                rate: 68.86,
+              },
+              {
+                year: 1990,
+                value: 3924717,
+                rate: 69.54,
+              },
+              {
+                year: 1995,
+                value: 3942868,
+                rate: 69.27,
+              },
+              {
+                year: 2000,
+                value: 3832902,
+                rate: 67.44,
+              },
+              {
+                year: 2005,
+                value: 3696064,
+                rate: 65.68,
+              },
+              {
+                year: 2010,
+                value: 3482169,
+                rate: 63.24,
+              },
+              {
+                year: 2015,
+                value: 3190804,
+                rate: 59.29,
+              },
+              {
+                year: 2020,
+                value: 2945727,
+                rate: 56.38,
+              },
+              {
+                year: 2025,
+                value: 2781175,
+                rate: 55.44,
+              },
+              {
+                year: 2030,
+                value: 2594718,
+                rate: 54.15,
+              },
+              {
+                year: 2035,
+                value: 2394230,
+                rate: 52.66,
+              },
+              {
+                year: 2040,
+                value: 2140781,
+                rate: 50.01,
+              },
+              {
+                year: 2045,
+                value: 1931265,
+                rate: 48.22,
+              },
+            ],
+          },
+          {
+            label: '老年人口',
+            data: [
+              {
+                year: 1960,
+                value: 212063,
+                rate: 4.21,
+              },
+              {
+                year: 1965,
+                value: 249318,
+                rate: 4.82,
+              },
+              {
+                year: 1970,
+                value: 299069,
+                rate: 5.77,
+              },
+              {
+                year: 1975,
+                value: 366651,
+                rate: 6.87,
+              },
+              {
+                year: 1980,
+                value: 451727,
+                rate: 8.1,
+              },
+              {
+                year: 1985,
+                value: 549487,
+                rate: 9.68,
+              },
+              {
+                year: 1990,
+                value: 674881,
+                rate: 11.96,
+              },
+              {
+                year: 1995,
+                value: 844927,
+                rate: 14.84,
+              },
+              {
+                year: 2000,
+                value: 1031552,
+                rate: 18.15,
+              },
+              {
+                year: 2005,
+                value: 1205692,
+                rate: 21.42,
+              },
+              {
+                year: 2010,
+                value: 1358068,
+                rate: 24.66,
+              },
+              {
+                year: 2015,
+                value: 1558387,
+                rate: 28.96,
+              },
+              {
+                year: 2020,
+                value: 1664023,
+                rate: 31.85,
+              },
+              {
+                year: 2025,
+                value: 1723702,
+                rate: 34.36,
+              },
+              {
+                year: 2030,
+                value: 1731567,
+                rate: 36.14,
+              },
+              {
+                year: 2035,
+                value: 1728745,
+                rate: 38.02,
+              },
+              {
+                year: 2040,
+                value: 1748560,
+                rate: 40.85,
+              },
+              {
+                year: 2045,
+                value: 1713531,
+                rate: 42.79,
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
 
   return json.result;
 }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,0 +1,21 @@
+'use server';
+
+export default async function getPrefectures() {
+  const res = await fetch(
+    `https://yumemi-frontend-engineer-codecheck-api.vercel.app/api/v1/prefectures`,
+    {
+      method: 'GET',
+      headers: {
+        'X-API-KEY': process.env.X_API_KEY || '',
+      },
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch prefectures');
+  }
+
+  const json = await res.json();
+
+  return json.result;
+}

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -76,3 +76,27 @@ export async function getPrefectures() {
 
   return json.result;
 }
+
+export async function getPopulation(prefCode: number) {
+  if (prefCode < 1 || prefCode > 47) {
+    throw new Error(`There is no prefecture with the code ${prefCode}`);
+  }
+
+  const res = await fetch(
+    `https://yumemi-frontend-engineer-codecheck-api.vercel.app/api/v1/population/composition/perYear?prefCode=${prefCode}`,
+    {
+      method: 'GET',
+      headers: {
+        'X-API-KEY': process.env.X_API_KEY || '',
+      },
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch prefectures');
+  }
+
+  const json = await res.json();
+
+  return json.result;
+}


### PR DESCRIPTION
### 実装内容:
- `getPrefectures` と `getPopulation` の API データ取得を実装。
- 開発中の API 呼び出し回数を最小限に抑えるためにローカル開発用のモックデータを追加。
- 取得した都道府県データを用いて、シンプルなチェックボックス UI を構築。

### 関連 Issue :
- Closes #1 
- Closes #2 
- Closes #3 