### PR TITLE
都道府県選択ステート管理とシフト複数選択機能を追加

### DIFF
--- a/src/components/PrefectureSelector.tsx
+++ b/src/components/PrefectureSelector.tsx
@@ -16,8 +16,31 @@ export default function PrefectureSelector({
     );
   };
 
+  const selectAll = () => {
+    const allPrefCodes = prefectures.map((pref) => pref.prefCode);
+    setSelectedPrefectures(allPrefCodes);
+  };
+
+  const deselectAll = () => {
+    setSelectedPrefectures([]);
+  };
+
   return (
     <>
+      <div className="flex space-x-4 mb-4">
+        <button
+          onClick={selectAll}
+          className="px-4 py-2 bg-blue-500 text-white rounded"
+        >
+          Select All
+        </button>
+        <button
+          onClick={deselectAll}
+          className="px-4 py-2 bg-red-500 text-white rounded"
+        >
+          Deselect All
+        </button>
+      </div>
       <div className="flex flex-wrap w-108 space-x-2">
         {prefectures.map(
           (prefecture: { prefCode: number; prefName: string }) => {

--- a/src/components/PrefectureSelector.tsx
+++ b/src/components/PrefectureSelector.tsx
@@ -1,10 +1,21 @@
 'use client';
+import { useState } from 'react';
 
 export default function PrefectureSelector({
   prefectures,
 }: {
   prefectures: { prefCode: number; prefName: string }[];
 }) {
+  const [selectedPrefectures, setSelectedPrefectures] = useState<number[]>([]);
+
+  const toggleSelection = (prefCode: number) => {
+    setSelectedPrefectures((prevSelected) =>
+      prevSelected.includes(prefCode)
+        ? prevSelected.filter((code) => code !== prefCode)
+        : [...prevSelected, prefCode]
+    );
+  };
+
   return (
     <>
       <div className="flex flex-wrap w-108 space-x-2">
@@ -15,6 +26,8 @@ export default function PrefectureSelector({
                 <input
                   type="checkbox"
                   id={`pref-${prefecture.prefCode}`}
+                  checked={selectedPrefectures.includes(prefecture.prefCode)}
+                  onChange={() => toggleSelection(prefecture.prefCode)}
                 ></input>
                 <label htmlFor={`pref-${prefecture.prefCode}`}>
                   {prefecture.prefName}

--- a/src/components/PrefectureSelector.tsx
+++ b/src/components/PrefectureSelector.tsx
@@ -8,14 +8,6 @@ export default function PrefectureSelector({
 }) {
   const [selectedPrefectures, setSelectedPrefectures] = useState<number[]>([]);
 
-  const toggleSelection = (prefCode: number) => {
-    setSelectedPrefectures((prevSelected) =>
-      prevSelected.includes(prefCode)
-        ? prevSelected.filter((code) => code !== prefCode)
-        : [...prevSelected, prefCode]
-    );
-  };
-
   const selectAll = () => {
     const allPrefCodes = prefectures.map((pref) => pref.prefCode);
     setSelectedPrefectures(allPrefCodes);
@@ -23,6 +15,48 @@ export default function PrefectureSelector({
 
   const deselectAll = () => {
     setSelectedPrefectures([]);
+  };
+
+  const [lastClickedPrefCode, setLastClickedPrefCode] = useState<number | null>(
+    null
+  );
+
+  const handleCheckboxClick = (
+    prefCode: number,
+    event: React.MouseEvent<HTMLInputElement>
+  ) => {
+    if (event.shiftKey && lastClickedPrefCode !== null) {
+      const start = Math.min(lastClickedPrefCode, prefCode);
+      const end = Math.max(lastClickedPrefCode, prefCode);
+
+      setSelectedPrefectures((prevSelected) => {
+        const isSelecting = !prevSelected.includes(prefCode);
+
+        const newSelected = [...prevSelected];
+        for (let code = start; code <= end; code++) {
+          if (isSelecting) {
+            if (!newSelected.includes(code)) {
+              newSelected.push(code);
+            }
+          } else {
+            const index = newSelected.indexOf(code);
+            if (index !== -1) {
+              newSelected.splice(index, 1);
+            }
+          }
+        }
+
+        return newSelected;
+      });
+    } else {
+      setSelectedPrefectures((prevSelected) =>
+        prevSelected.includes(prefCode)
+          ? prevSelected.filter((code) => code !== prefCode)
+          : [...prevSelected, prefCode]
+      );
+    }
+
+    setLastClickedPrefCode(prefCode);
   };
 
   return (
@@ -50,7 +84,8 @@ export default function PrefectureSelector({
                   type="checkbox"
                   id={`pref-${prefecture.prefCode}`}
                   checked={selectedPrefectures.includes(prefecture.prefCode)}
-                  onChange={() => toggleSelection(prefecture.prefCode)}
+                  onClick={(e) => handleCheckboxClick(prefecture.prefCode, e)}
+                  onChange={() => {}} // Dummy handler for React warnings
                 ></input>
                 <label htmlFor={`pref-${prefecture.prefCode}`}>
                   {prefecture.prefName}

--- a/src/components/PrefectureSelector.tsx
+++ b/src/components/PrefectureSelector.tsx
@@ -59,6 +59,10 @@ export default function PrefectureSelector({
     setLastClickedPrefCode(prefCode);
   };
 
+  // TODO: Refactor checkbox + label elements into a separate React component (PrefectureCheckbox).
+  // As part of this refactor, implement shift-click support on <label> to ensure consistent selection
+  // behavior when clicking either the checkbox or the label.
+
   return (
     <>
       <div className="flex space-x-4 mb-4">


### PR DESCRIPTION
### 実装内容:
- 都道府県の選択ステート管理機能を追加
- すべて選択・選択解除機能を実装
- シフトキーを押しながら複数の都道府県を選択・解除できる機能を実装
- チェックボックスのラベルをクリックして選択できるように対応
    ※ ラベルのシフトクリックによる複数選択は未対応（リファクタリングと共にTODOとして追加済み）

### 動作デモ
https://github.com/user-attachments/assets/8fb38412-8879-45f0-a220-6efe34879d08

### 関連 Issue:
- Closes #5
- Closes #6
- Closes #7