### PR TITLE
リファクタリング: コンポーネント分割 & 共通ロジックの抽出

### DIFF
--- a/src/components/CustomLegend.tsx
+++ b/src/components/CustomLegend.tsx
@@ -1,0 +1,109 @@
+'use client';
+import React, { useRef, useEffect, useState } from 'react';
+
+interface CustomLegendItem {
+  value?: string | number;
+  color?: string;
+  dataKey?: string | number;
+  payload?: {
+    legendType?: string;
+  };
+}
+
+interface CustomLegendProps {
+  payload?: CustomLegendItem[];
+  selectedPrefectures: number[];
+  getPrefectureName: (key: string | number) => string;
+}
+
+const CustomLegend = ({
+  payload = [],
+  selectedPrefectures,
+  getPrefectureName,
+}: CustomLegendProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [scrollingDown, setScrollingDown] = useState(true);
+
+  useEffect(() => {
+    const scrollContainer = containerRef.current;
+    if (!scrollContainer) return;
+
+    if (selectedPrefectures.length < 8) return;
+
+    const scrollStep = 1;
+    const intervalTime = 58 - selectedPrefectures.length;
+    let interval: ReturnType<typeof setInterval>;
+
+    const startScrolling = () => {
+      interval = setInterval(() => {
+        if (scrollingDown) {
+          scrollContainer.scrollTop += scrollStep;
+          if (
+            scrollContainer.scrollTop + scrollContainer.clientHeight >=
+            scrollContainer.scrollHeight
+          ) {
+            setScrollingDown(false);
+          }
+        } else {
+          scrollContainer.scrollTop -= scrollStep;
+          if (scrollContainer.scrollTop <= 0) {
+            setScrollingDown(true);
+          }
+        }
+      }, intervalTime);
+    };
+
+    startScrolling();
+
+    const stopAutoScroll = () => {
+      clearInterval(interval);
+    };
+
+    scrollContainer.addEventListener('mouseenter', stopAutoScroll);
+    scrollContainer.addEventListener('mouseleave', startScrolling);
+
+    return () => {
+      scrollContainer.removeEventListener('mouseenter', stopAutoScroll);
+      scrollContainer.removeEventListener('mouseleave', startScrolling);
+      stopAutoScroll();
+    };
+  }, [scrollingDown, selectedPrefectures]);
+
+  return (
+    <div
+      className="hide-scrollbar flex h-[500px] flex-wrap justify-between space-y-2 overflow-y-scroll py-50 pr-2 pl-2 lg:pr-4"
+      ref={containerRef}
+    >
+      <div className="pointer-events-none absolute top-0 left-0 h-40 w-full bg-gradient-to-b from-white via-white/90 to-transparent" />
+      <div className="pointer-events-none absolute top-0 right-0 h-full w-0.5 bg-gradient-to-b from-white via-gray-300 to-white" />
+
+      {payload
+        .filter((entry: CustomLegendItem) =>
+          entry.payload ? entry.payload.legendType !== 'none' : false
+        )
+        .map((entry: CustomLegendItem) => (
+          <div
+            key={`item-${entry.value}`}
+            className="flex min-w-25 items-center text-lg"
+          >
+            <span
+              className="mr-0.5 inline-block h-0.5 w-3"
+              style={{ backgroundColor: entry.color }}
+            ></span>
+            <span
+              className="mr-0.5 inline-block h-0.5 w-0.5"
+              style={{ backgroundColor: entry.color }}
+            ></span>
+            <span
+              className="mr-2 inline-block h-0.5 w-0.5"
+              style={{ backgroundColor: entry.color }}
+            ></span>
+            {entry.value !== undefined ? getPrefectureName(entry.value) : ''}
+          </div>
+        ))}
+      <div className="pointer-events-none absolute bottom-0 left-0 h-40 w-full bg-linear-to-t from-white via-white/90 to-transparent" />
+    </div>
+  );
+};
+
+export default CustomLegend;

--- a/src/components/PrefectureCheckbox.tsx
+++ b/src/components/PrefectureCheckbox.tsx
@@ -1,0 +1,49 @@
+'use client';
+import React from 'react';
+
+interface PrefectureCheckboxProps {
+  prefCode: number;
+  prefName: string;
+  checked: boolean;
+  onCheckboxClick: (
+    prefCode: number,
+    event: React.MouseEvent<HTMLInputElement>
+  ) => void;
+}
+
+const PrefectureCheckbox = ({
+  prefCode,
+  prefName,
+  checked,
+  onCheckboxClick,
+}: PrefectureCheckboxProps) => {
+  const handleInputClick = (e: React.MouseEvent<HTMLInputElement>) => {
+    onCheckboxClick(prefCode, e);
+  };
+
+  const handleLabelClick = (e: React.MouseEvent<HTMLLabelElement>) => {
+    // Pass the event from the label to the checkbox click handler.
+    // Casting the event as the expected type since both share the 'shiftKey' property.
+    onCheckboxClick(
+      prefCode,
+      e as unknown as React.MouseEvent<HTMLInputElement>
+    );
+  };
+
+  return (
+    <div className="flex w-25 space-x-2">
+      <input
+        type="checkbox"
+        id={`pref-${prefCode}`}
+        checked={checked}
+        onClick={handleInputClick}
+        onChange={() => {}} // Dummy handler to satisfy React
+      />
+      <label htmlFor={`pref-${prefCode}`} onClick={handleLabelClick}>
+        {prefName}
+      </label>
+    </div>
+  );
+};
+
+export default PrefectureCheckbox;

--- a/src/components/PrefectureSelector.tsx
+++ b/src/components/PrefectureSelector.tsx
@@ -1,5 +1,7 @@
+'use client';
 import { Prefecture } from '@/types/interfaces';
 import { useState } from 'react';
+import PrefectureCheckbox from './PrefectureCheckbox';
 
 export default function PrefectureSelector({
   prefectures,
@@ -60,10 +62,6 @@ export default function PrefectureSelector({
     setLastClickedPrefCode(prefCode);
   };
 
-  // TODO: Refactor checkbox + label elements into a separate React component (PrefectureCheckbox).
-  // As part of this refactor, implement shift-click support on <label> to ensure consistent selection
-  // behavior when clicking either the checkbox or the label.
-
   const populationTypes = [
     { value: '総人口', label: '総人口' },
     { value: '年少人口', label: '年少人口' },
@@ -105,18 +103,13 @@ export default function PrefectureSelector({
       </div>
       <div className="flex max-w-104 flex-wrap gap-1">
         {prefectures.map((prefecture) => (
-          <div key={prefecture.prefCode} className="flex w-25 space-x-2">
-            <input
-              type="checkbox"
-              id={`pref-${prefecture.prefCode}`}
-              checked={selectedPrefectures.includes(prefecture.prefCode)}
-              onClick={(e) => handleCheckboxClick(prefecture.prefCode, e)}
-              onChange={() => {}} // Dummy handler for React warnings
-            ></input>
-            <label htmlFor={`pref-${prefecture.prefCode}`}>
-              {prefecture.prefName}
-            </label>
-          </div>
+          <PrefectureCheckbox
+            key={prefecture.prefCode}
+            prefCode={prefecture.prefCode}
+            prefName={prefecture.prefName}
+            checked={selectedPrefectures.includes(prefecture.prefCode)}
+            onCheckboxClick={handleCheckboxClick}
+          />
         ))}
       </div>
     </div>


### PR DESCRIPTION
### 実装内容
- CustomLegendをPopulationChartから切り出し、独立したコンポーネントとして実装
- PrefectureSelector内のチェックボックスとラベルの組み合わせを独立したPrefectureCheckboxコンポーネントに分離。Shiftクリックでの選択などの機能に変更ない
- PopulationChartにおけるLine要素の重複コードをrenderChartLines()ヘルパー関数に抽出

### 関連 Issue
今回の内部リファクタリングは機能変更を伴わない改善のため、Issue は作成していない